### PR TITLE
Only allow .json files for upload

### DIFF
--- a/src/app/components/elements/Button/index.tsx
+++ b/src/app/components/elements/Button/index.tsx
@@ -40,7 +40,7 @@ const Button: React.SFC<Props> = props => {
     const fileBtnComponent = () => {
         return (
             <label className={`${styles.button} ${styles.fileButton} ${props.className} ${styles[props.mod]}`}>
-                <input type="file" onClick={props.onClick} onChange={props.onChange} />
+                <input type="file" accept="application/json" onClick={props.onClick} onChange={props.onChange} />
                 <span>{props.text}</span>
                 {typeof props.icon !== 'undefined' ? <Icon name={props.icon} /> : null}
             </label>


### PR DESCRIPTION
Hi,

thanks for this plugin! :)

This small addition allows the user to only select json files, this reduces the risk that he accidentally uploads a wrong file and it also reduces the cognitive overhead while selecting a json file to upload.

![image](https://user-images.githubusercontent.com/22857823/98028819-f09b0a00-1e0e-11eb-9fe7-4bafc614e079.png)

Cheers,
Luka